### PR TITLE
implemented file persistence for issues, thorough testing, bug fixing for ai issue integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+package.json
+package-lock.json
+node_modules/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -133,6 +136,9 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+/data/
+*.log
 
 # Spyder project settings
 .spyderproject

--- a/src/gemini_api_client.py
+++ b/src/gemini_api_client.py
@@ -11,7 +11,8 @@ from dotenv import load_dotenv
 from src.ai_interface import IAIConversationClient
 from src.conversation import Conversation, Message, MessageRole
 
-# MyPy-safe dynamic typing for Gemini SDK
+# overall concern: why use requests if we can use the SDK's methods directly? future todo. We also keep self sessions but also gemini chat sessions. 
+
 if TYPE_CHECKING:
 
     class GenerativeModelConstructor(Protocol):
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 else:
     GenerativeModelConstructor = Any
 
-# Dynamic import that works at runtime
+# dynamic import
 genai = importlib.import_module("google.generativeai")
 genai_configure: Any = genai.configure
 genai_model_class: GenerativeModelConstructor = genai.GenerativeModel
@@ -88,7 +89,7 @@ class GeminiAPIClient(IAIConversationClient):
         headers = {"Content-Type": "application/json"}
 
         try:
-            # Add a timeout (e.g., 30 seconds) to prevent indefinite hanging
+            # add a timeout to prevent indefinite hanging
             response = requests.post(self._model_url, headers=headers, json=payload, timeout=30)
             response.raise_for_status()
             parsed = response.json()

--- a/src/issue_tracker.py
+++ b/src/issue_tracker.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import uuid
+import json 
+import os 
+import logging
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
 from src import Comment, Issue, IssueTrackerClient
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 
 class MemoryComment(Comment):
@@ -31,6 +36,24 @@ class MemoryComment(Comment):
     @property
     def created_at(self) -> str:
         return self._created_at
+    
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize comment to a dictionary."""
+        return {
+            "id": self._id,
+            "author": self._author,
+            "content": self._content,
+            "created_at": self._created_at,
+    }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MemoryComment:
+        """Deserialize comment from a dictionary."""
+        # creates a new instance, id will match but object is new; override generated uuid 
+        comment = cls(author=data["author"], content=data["content"])
+        comment._id = data["id"]
+        comment._created_at = data["created_at"]
+        return comment
 
 
 class MemoryIssue(Issue):
@@ -120,16 +143,52 @@ class MemoryIssue(Issue):
             self._priority = kwargs["priority"]
 
         self._updated_at = datetime.now(tz=timezone.utc).isoformat()
+    
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize issue and its comments to a dictionary."""
+        return {
+            "id": self._id,
+            "title": self._title,
+            "description": self._description,
+            "status": self._status,
+            "creator": self._creator,
+            "assignee": self._assignee,
+            "created_at": self._created_at,
+            "updated_at": self._updated_at,
+            "labels": self._labels,
+            "priority": self._priority,
+            "comments": [comment.to_dict() for comment in self._comments],
+        }
+    
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MemoryIssue:
+        """Deserialize issue and its comments from a dictionary."""
+        issue = cls(
+            title=data["title"],
+            description=data["description"],
+            creator=data["creator"],
+            status=data["status"],
+            assignee=data["assignee"],
+            labels=data["labels"],
+            priority=data["priority"],
+        )
+
+        issue._id = data["id"]
+        issue._created_at = data["created_at"]
+        issue._updated_at = data["updated_at"]
+
+        issue._comments = [MemoryComment.from_dict(c_data) for c_data in data["comments"]]
+        return issue
 
 
 class MemoryIssueTrackerClient(IssueTrackerClient):
     """An in-memory implementation of an Issue Tracker Client."""
 
     def __init__(self):
-        # Specify that this client works with MemoryIssue instances
+        # specify that this client works with MemoryIssue instances
         self._issues: dict[str, MemoryIssue] = {}
         self._current_user = (
-            "default_user"  # In a real system, this would come from auth
+            "default_user"  # todo: implement auth system 
         )
 
     def set_current_user(self, username: str) -> None:
@@ -146,9 +205,7 @@ class MemoryIssueTrackerClient(IssueTrackerClient):
                 match = True
                 for key, value in filters.items():
                     if key == "labels" and isinstance(value, list):
-                        # Add assertion to help the type checker
                         assert isinstance(value, list)
-                        # Check if any of the requested labels are in the issue's labels
                         if not any(label in issue.labels for label in value):
                             match = False
                             break
@@ -203,7 +260,6 @@ class MemoryIssueTrackerClient(IssueTrackerClient):
 
     def search_issues(self, query: str) -> Iterator[MemoryIssue]:
         """Search for issues matching the query string."""
-        # Simple case-insensitive search in title and description
         query = query.lower()
 
         matching_issues = [
@@ -227,3 +283,155 @@ class MemoryIssueTrackerClient(IssueTrackerClient):
 
     def get_current_user(self) -> str:
         return self._current_user
+    
+
+class FileIssueTrackerClient(IssueTrackerClient):
+    """An Issue Tracker Client that persists issues to a JSON file."""
+
+    def __init__(self, filepath: str = "data/issues.json"):
+        self._filepath = filepath
+        self._issues: dict[str, MemoryIssue] = {}
+        self._current_user = "default_user" 
+        self._ensure_data_dir_exists()
+        self._load_issues()
+
+    def _ensure_data_dir_exists(self):
+        """Create the data directory if it doesn't exist."""
+        dir_name = os.path.dirname(self._filepath)
+        if dir_name and not os.path.exists(dir_name):
+            try:
+                os.makedirs(dir_name)
+                logging.info(f"Created data directory: {dir_name}")
+            except OSError as e:
+                logging.error(f"Failed to create data directory {dir_name}: {e}")
+                # log for now, potential raise later 
+
+    def _load_issues(self) -> None:
+        """Load issues from the JSON file."""
+        if not os.path.exists(self._filepath):
+            logging.warning(f"Data file not found: {self._filepath}. Starting fresh.")
+            self._issues = {}
+            return
+
+        try:
+            with open(self._filepath, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, dict):
+                     self._issues = {
+                        issue_id: MemoryIssue.from_dict(issue_data)
+                        for issue_id, issue_data in data.items()
+                     }
+                     logging.info(f"Loaded {len(self._issues)} issues from {self._filepath}")
+                else:
+                    logging.error(f"Invalid data format in {self._filepath}. Expected a dictionary. Starting fresh.")
+                    self._issues = {}
+        except json.JSONDecodeError:
+            logging.exception(f"Failed to decode JSON from {self._filepath}. File might be corrupted. Starting fresh.")
+            self._issues = {} 
+        except Exception:
+             logging.exception(f"An unexpected error occurred while loading {self._filepath}. Starting fresh.")
+             self._issues = {} 
+
+
+    def _save_issues(self) -> None:
+        """Save the current state of issues to the JSON file."""
+        try:
+            data_to_save = {
+                issue_id: issue.to_dict()
+                for issue_id, issue in self._issues.items()
+            }
+            with open(self._filepath, "w", encoding="utf-8") as f:
+                json.dump(data_to_save, f, indent=2) 
+            logging.debug(f"Saved {len(self._issues)} issues to {self._filepath}")
+        except Exception: 
+            logging.exception(f"Failed to save issues to {self._filepath}")
+
+    def set_current_user(self, username: str) -> None:
+        """Set the current user for operations."""
+        self._current_user = username
+
+    def get_current_user(self) -> str:
+        return self._current_user
+
+    def get_issues(self, filters: dict[str, Any] | None = None) -> Iterator[Issue]:
+        """Return an iterator of issues, optionally filtered."""
+        issues = self._issues.values()
+        if filters:
+            filtered_issues = []
+            for issue in issues:
+                match = True
+                for key, value in filters.items():
+                    attr_value = getattr(issue, key, None)
+                    if key == "labels" and isinstance(value, list):
+                        issue_labels = getattr(issue, 'labels', [])
+                        if not isinstance(issue_labels, list) or not any(label in issue_labels for label in value):
+                            match = False
+                            break
+                    elif attr_value != value:
+                         match = False
+                         break
+                if match:
+                    filtered_issues.append(issue)
+            return iter(filtered_issues)
+        return iter(issues)
+
+
+    def get_issue_dict(self) -> dict[str, MemoryIssue]:
+        """Return all issues as a dictionary."""
+        # optimistically assumes in-memory is up to date
+        return self._issues.copy() 
+
+    def get_issue(self, issue_id: str) -> Issue:
+        """Return a specific issue by ID."""
+        if issue_id not in self._issues:
+            error_message = f"Issue with ID {issue_id} not found"
+            raise ValueError(error_message)
+        return self._issues[issue_id]
+
+    def create_issue(self, title: str, description: str, **kwargs: Any) -> Issue:
+        """Create a new issue, save it, and return it."""
+        issue = MemoryIssue(title, description, self._current_user, **kwargs)
+        self._issues[issue.id] = issue
+        self._save_issues()
+        return issue
+
+    def update_issue(self, issue_id: str, **kwargs: Any) -> Issue:
+        """Update an existing issue, save it, and return the updated version."""
+        issue = self.get_issue(issue_id) 
+        if not isinstance(issue, MemoryIssue):
+            raise TypeError("Issue found is not an updatable MemoryIssue instance")
+        issue.update(**kwargs)
+        self._save_issues()
+        return issue
+
+    def add_comment(self, issue_id: str, content: str) -> Comment:
+        """Add a comment to an issue, save it, and return the created comment."""
+        issue = self.get_issue(issue_id) 
+        if not isinstance(issue, MemoryIssue):
+             raise TypeError("Issue found is not a MemoryIssue instance that can accept comments")
+
+        comment = MemoryComment(self._current_user, content)
+        issue.add_comment(comment)
+        self._save_issues()
+        return comment
+
+    def search_issues(self, query: str) -> Iterator[Issue]:
+        """Search for issues matching the query string."""
+        query = query.lower()
+        matching_issues = [
+            issue
+            for issue in self._issues.values()
+            if query in issue.title.lower() or query in issue.description.lower()
+        ]
+        return iter(matching_issues)
+
+
+    def close_issue(self, issue_id: str, resolution: str) -> Issue:
+        """Close an issue with a given resolution and save."""
+        issue = self.get_issue(issue_id) 
+        if not isinstance(issue, MemoryIssue):
+            raise TypeError("Issue found is not an updatable MemoryIssue instance")
+
+        issue.update(status="closed")
+        self.add_comment(issue_id, f"Closed with resolution: {resolution}")
+        return issue

--- a/src/issue_tracker_interface.py
+++ b/src/issue_tracker_interface.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Any, Iterator, Protocol, runtime_checkable
 
 
@@ -122,6 +123,8 @@ class IssueTrackerClient(Protocol):
 
 def get_issue_tracker_client() -> IssueTrackerClient:
     """Return an instance of an Issue Tracker Client."""
-    from src.issue_tracker import MemoryIssueTrackerClient
-
-    return MemoryIssueTrackerClient()
+    from src.issue_tracker import FileIssueTrackerClient # file-based ver 
+    # from src.issue_tracker import MemoryIssueTrackerClient
+    # return MemoryIssueTrackerClient() 
+    filepath = os.getenv("ISSUE_DATA_PATH", "data/issues.json")
+    return FileIssueTrackerClient(filepath=filepath)

--- a/tests/ai_issue_integration_test.py
+++ b/tests/ai_issue_integration_test.py
@@ -1,16 +1,22 @@
 import pytest
+from pathlib import Path
 
 from src.ai_client import AIConversationClient
 from src.ai_issue_integration import AIIssueIntegration
-from src.issue_tracker import MemoryIssueTrackerClient
+from src.issue_tracker import FileIssueTrackerClient
 from tests.dummy_api_client import DummyAPIClient
+# from src.issue_tracker import MemoryIssueTrackerClient
 
 
 @pytest.fixture
-def integration():
+def integration(tmp_path: Path):
     ai_api_client = DummyAPIClient()
     ai_client = AIConversationClient(ai_api_client)
-    issue_client = MemoryIssueTrackerClient()
+
+    data_dir = tmp_path / "ai_integration_test_data"
+    test_file = data_dir / "issues.json"
+    
+    issue_client = FileIssueTrackerClient(filepath=str(test_file))
     return AIIssueIntegration(ai_client, issue_client)
 
 

--- a/tests/test_issue_tracker.py
+++ b/tests/test_issue_tracker.py
@@ -1,19 +1,37 @@
 from __future__ import annotations
 
 import pytest
+import json
+import logging
+import os
 
-from src.issue_tracker import MemoryComment, MemoryIssue, MemoryIssueTrackerClient
+from pathlib import Path
+from src.issue_tracker import MemoryComment, MemoryIssue, FileIssueTrackerClient
+from src.issue_tracker_interface import Issue, Comment
+
+@pytest.fixture
+def data_file(tmp_path: Path) -> Path:
+    """Provides a temporary, unique file path for issue data for each test."""
+    data_dir = tmp_path / "test_data"
+    return data_dir / "issues_test.json"
 
 
 @pytest.fixture
-def client():
-    """Fixture to create a MemoryIssueTrackerClient instance."""
-    return MemoryIssueTrackerClient()
+def client(data_file: Path) -> FileIssueTrackerClient:
+    """Fixture to create a FileIssueTrackerClient instance using a temp file."""
+    instance = FileIssueTrackerClient(filepath=str(data_file))
+    return instance
 
 
 @pytest.fixture
-def client_with_issues(client):
-    """Fixture to create a client with some pre-populated issues."""
+def client_with_issues(client: FileIssueTrackerClient) -> FileIssueTrackerClient:
+    """
+    Fixture to create a client with some pre-populated issues.
+
+    Relies on the client fixture which uses a unique temp file. Operations will save to that temp file. 
+
+    Operations here will trigger saves to that temp file.
+    """
     client.set_current_user("user1")
     client.create_issue(
         "Bug 1",
@@ -37,24 +55,24 @@ def client_with_issues(client):
         labels=["bug", "backend"],
         assignee="user1",
     )
-    client.set_current_user("default_user")  # Reset user for subsequent tests
+    client.set_current_user("default_user")  # reset user for subsequent tests
     return client
 
-
-def test_init(client):
-    """Test client initialization."""
+def test_init(client: FileIssueTrackerClient, data_file: Path):
+    """Test client initialization with a non-existent file."""
     assert isinstance(client.get_issue_dict(), dict)
     assert len(client.get_issue_dict()) == 0
     assert client.get_current_user() == "default_user"
+    assert data_file.parent.exists()
 
 
-def test_set_current_user(client):
+def test_set_current_user(client: FileIssueTrackerClient):
     """Test setting the current user."""
     client.set_current_user("test_user")
     assert client.get_current_user() == "test_user"
 
 
-def test_create_issue(client):
+def test_create_issue(client: FileIssueTrackerClient, data_file: Path):
     """Test creating a new issue."""
     client.set_current_user("creator_user")
     issue = client.create_issue(
@@ -75,30 +93,43 @@ def test_create_issue(client):
     assert issue.id in client.get_issue_dict()
     assert client.get_issue_dict()[issue.id] == issue
 
+    assert data_file.exists()
+    client2 = FileIssueTrackerClient(filepath=str(data_file))
+    assert issue.id in client2.get_issue_dict()
+    loaded_issue = client2.get_issue(issue.id)
+    assert loaded_issue.title == "New Issue"
+    assert loaded_issue.creator == "creator_user"
 
-def test_get_issue(client_with_issues):
-    """Test retrieving a specific issue."""
-    # Get the ID of the first created issue
-    issue_id = next(iter(client_with_issues.get_issue_dict().keys()))
+
+def test_get_issue(client_with_issues: FileIssueTrackerClient):
+    """Test retrieving a specific issue (should load from file implicitly)."""    # Get the ID of the first created issue
+    issue_id = None
+    for issue in client_with_issues.get_issues():
+        if issue.title == "Bug 1":
+            issue_id = issue.id
+            break
+        
+    assert issue_id is not None, "Failed to find 'Bug 1' in fixture setup"
+
     issue = client_with_issues.get_issue(issue_id)
     assert issue.id == issue_id
     assert issue.title == "Bug 1"
 
 
-def test_get_issue_not_found(client):
+def test_get_issue_not_found(client: FileIssueTrackerClient):
     """Test retrieving a non-existent issue raises ValueError."""
     with pytest.raises(ValueError, match="Issue with ID non_existent_id not found"):
         client.get_issue("non_existent_id")
 
 
-def test_get_issues_no_filters(client_with_issues):
+def test_get_issues_no_filters(client_with_issues: FileIssueTrackerClient):
     """Test retrieving all issues without filters."""
     issues = list(client_with_issues.get_issues())
     assert len(issues) == 3
     assert {issue.title for issue in issues} == {"Bug 1", "Feature Request", "Bug 2"}
 
 
-def test_get_issues_with_filters(client_with_issues):
+def test_get_issues_with_filters(client_with_issues: FileIssueTrackerClient):
     """Test retrieving issues with various filters."""
     # Filter by status
     open_issues = list(client_with_issues.get_issues(filters={"status": "open"}))
@@ -135,11 +166,9 @@ def test_get_issues_with_filters(client_with_issues):
     assert open_bug_issues[0].title == "Bug 1"
 
 
-def test_update_issue(client_with_issues):
+def test_update_issue(client_with_issues: FileIssueTrackerClient, data_file: Path):
     """Test updating an existing issue."""
-    issue_id = next(
-        iter(client_with_issues.get_issue_dict().keys()),
-    )  # Get ID of "Bug 1"
+    issue_id = next(issue.id for issue in client_with_issues.get_issues() if issue.title == "Bug 1")
     original_issue = client_with_issues.get_issue(issue_id)
     original_updated_at = original_issue.updated_at
 
@@ -158,25 +187,24 @@ def test_update_issue(client_with_issues):
     assert updated_issue.assignee == "user3"
     assert updated_issue.labels == ["bug", "critical"]
     assert updated_issue.priority == "critical"
-    assert updated_issue.updated_at != original_updated_at  # Check timestamp updated
+    assert updated_issue.updated_at != original_updated_at 
 
-    # Verify the update is reflected in the internal store
-    stored_issue = client_with_issues.get_issue(issue_id)
-    assert stored_issue.title == "Updated Bug 1"
-    assert stored_issue.status == "in_progress"
+    # persistence check 
+    client2 = FileIssueTrackerClient(filepath=str(data_file))
+    loaded_issue = client2.get_issue(issue_id)
+    assert loaded_issue.title == "Updated Bug 1"
+    assert loaded_issue.status == "in_progress"
 
 
-def test_update_issue_not_found(client):
+def test_update_issue_not_found(client: FileIssueTrackerClient):
     """Test updating a non-existent issue raises ValueError."""
     with pytest.raises(ValueError, match="Issue with ID non_existent_id not found"):
         client.update_issue("non_existent_id", title="Doesn't Matter")
 
 
-def test_add_comment(client_with_issues):
-    """Test adding a comment to an issue."""
-    issue_id = next(
-        iter(client_with_issues.get_issue_dict().keys()),
-    )  # Get ID of "Bug 1"
+def test_add_comment(client_with_issues: FileIssueTrackerClient, data_file: Path):
+    """Test adding a comment to an issue and that it persists."""
+    issue_id = next(issue.id for issue in client_with_issues.get_issues() if issue.title == "Bug 1")
     client_with_issues.set_current_user("commenter_user")
     comment_content = "This is a test comment."
 
@@ -188,25 +216,24 @@ def test_add_comment(client_with_issues):
     assert comment.id is not None
     assert comment.created_at is not None
 
-    # Verify comment is added to the issue
-    issue = client_with_issues.get_issue(issue_id)
-    comments = list(issue.get_comments())
-    assert len(comments) == 1
-    assert comments[0] == comment
-    assert comments[0].content == comment_content
+    # persistence check
+    client2 = FileIssueTrackerClient(filepath=str(data_file))
+    loaded_issue = client2.get_issue(issue_id)
+    loaded_comments = list(loaded_issue.get_comments())
+    assert len(loaded_comments) > 0 
+    assert loaded_comments[-1].content == comment_content
+    assert loaded_comments[-1].author == "commenter_user"
 
 
-def test_add_comment_issue_not_found(client):
+def test_add_comment_issue_not_found(client: FileIssueTrackerClient):
     """Test adding a comment to a non-existent issue raises ValueError."""
     with pytest.raises(ValueError, match="Issue with ID non_existent_id not found"):
         client.add_comment("non_existent_id", "Some comment")
 
 
-def test_get_comments(client_with_issues):
+def test_get_comments(client_with_issues: FileIssueTrackerClient, data_file: Path):
     """Test retrieving comments from an issue."""
-    issue_id = next(
-        iter(client_with_issues.get_issue_dict().keys()),
-    )  # Get ID of "Bug 1"
+    issue_id = next(issue.id for issue in client_with_issues.get_issues() if issue.title == "Feature Request")
     client_with_issues.set_current_user("user_a")
     client_with_issues.add_comment(issue_id, "Comment 1")
     client_with_issues.set_current_user("user_b")
@@ -221,10 +248,23 @@ def test_get_comments(client_with_issues):
     assert comments[1].content == "Comment 2"
     assert comments[1].author == "user_b"
 
+     # retrieve issue again from the same client, test if comment(s) in memory
+    issue = client_with_issues.get_issue(issue_id)
+    comments = list(issue.get_comments())
 
-def test_search_issues(client_with_issues):
+    assert len(comments) == 2
+    assert comments[0].content == "Comment 1"
+    assert comments[1].content == "Comment 2"
+
+    # verify persistence
+    client2 = FileIssueTrackerClient(filepath=str(data_file))
+    loaded_issue = client2.get_issue(issue_id)
+    loaded_comments = list(loaded_issue.get_comments())
+    assert len(loaded_comments) == 2
+
+
+def test_search_issues(client_with_issues: FileIssueTrackerClient):
     """Test searching issues by query string."""
-    # Search in title
     results_bug = list(client_with_issues.search_issues("Bug"))
     assert len(results_bug) == 2
     assert {issue.title for issue in results_bug} == {"Bug 1", "Bug 2"}
@@ -235,19 +275,148 @@ def test_search_issues(client_with_issues):
 
     results_description = list(
         client_with_issues.search_issues("another bug"),
-    )  # Search in description (case-insensitive)
+    ) 
     assert len(results_description) == 1
     assert results_description[0].title == "Bug 2"
 
-    # Search matching both title and description
     results_desc_bug = list(client_with_issues.search_issues("description"))
     assert (
         len(results_desc_bug) == 2
-    )  # Matches "Description for bug 1" and "Another bug description"
+    )  
     assert {issue.title for issue in results_desc_bug} == {"Bug 1", "Bug 2"}
 
 
-def test_search_issues_no_results(client_with_issues):
+def test_search_issues_no_results(client_with_issues: FileIssueTrackerClient):
     """Test searching issues with a query that yields no results."""
     results = list(client_with_issues.search_issues("non_matching_query"))
     assert len(results) == 0
+
+
+def test_close_issue(client_with_issues: FileIssueTrackerClient, data_file: Path):
+    """Test closing an issue and that it persists."""
+    issue_id = next(issue.id for issue in client_with_issues.get_issues() if issue.title == "Bug 1")
+
+    closed_issue = client_with_issues.close_issue(issue_id, "fixed")
+
+    assert closed_issue.status == "closed"
+
+    comments = list(closed_issue.get_comments())
+    assert len(comments) > 0
+    assert "Closed with resolution: fixed" in comments[-1].content
+
+    # persistence check 
+    client2 = FileIssueTrackerClient(filepath=str(data_file))
+    loaded_issue = client2.get_issue(issue_id)
+    assert loaded_issue.status == "closed"
+    loaded_comments = list(loaded_issue.get_comments())
+    assert "Closed with resolution: fixed" in loaded_comments[-1].content
+
+# file-persistence specific tests
+
+def test_load_existing_file(data_file: Path):
+    """Test loading data from a pre-existing valid JSON file."""
+    # manually created test issues 
+    issue_id_1 = "issue_abc"
+    issue_id_2 = "issue_def"
+    initial_data = {
+        issue_id_1: {
+            "id": issue_id_1, "title": "Pre-existing Issue", "description": "Loaded from file",
+            "status": "open", "creator": "file_creator", "assignee": None,
+            "created_at": "2023-01-01T10:00:00Z", "updated_at": "2023-01-01T11:00:00Z",
+            "labels": ["persistent"], "priority": None, "comments": []
+        },
+         issue_id_2: {
+            "id": issue_id_2, "title": "Another Pre-existing", "description": "Also loaded",
+            "status": "closed", "creator": "file_creator_2", "assignee": "someone",
+            "created_at": "2023-01-02T12:00:00Z", "updated_at": "2023-01-02T13:00:00Z",
+            "labels": [], "priority": "low", "comments": [
+                {"id": "comment_123", "author": "commenter", "content": "Pre-loaded comment", "created_at": "2023-01-02T12:30:00Z"}
+            ]
+        }
+    }
+    data_file.parent.mkdir(parents=True, exist_ok=True)
+    data_file.write_text(json.dumps(initial_data, indent=2))
+
+    client = FileIssueTrackerClient(filepath=str(data_file))
+
+    assert len(client.get_issue_dict()) == 2
+    assert issue_id_1 in client.get_issue_dict()
+    assert issue_id_2 in client.get_issue_dict()
+
+    loaded_issue_1 = client.get_issue(issue_id_1)
+    assert loaded_issue_1.title == "Pre-existing Issue"
+    assert loaded_issue_1.labels == ["persistent"]
+
+    loaded_issue_2 = client.get_issue(issue_id_2)
+    assert loaded_issue_2.status == "closed"
+    assert loaded_issue_2.assignee == "someone"
+    comments = list(loaded_issue_2.get_comments())
+    assert len(comments) == 1
+    assert comments[0].content == "Pre-loaded comment"
+    assert comments[0].author == "commenter"
+
+
+def test_load_empty_file(data_file: Path, caplog):
+    """Test loading from an empty file (should start fresh)."""
+    data_file.parent.mkdir(parents=True, exist_ok=True)
+    data_file.touch() 
+    assert data_file.read_text() == ""
+
+    with caplog.at_level(logging.WARNING):
+        client = FileIssueTrackerClient(filepath=str(data_file))
+        assert len(client.get_issue_dict()) == 0
+        assert f"Failed to decode JSON from {data_file}" in caplog.text \
+            or f"Invalid data format in {data_file}" in caplog.text \
+            or "Starting fresh" in caplog.text
+
+def test_load_invalid_json_file(data_file: Path, caplog):
+    """Test loading from a file with invalid JSON."""
+    data_file.parent.mkdir(parents=True, exist_ok=True)
+    data_file.write_text("this is not json {")
+
+    with caplog.at_level(logging.ERROR):
+        client = FileIssueTrackerClient(filepath=str(data_file))
+        assert len(client.get_issue_dict()) == 0
+        assert f"Failed to decode JSON from {data_file}" in caplog.text
+
+def test_load_wrong_json_type(data_file: Path, caplog):
+    """Test loading from valid JSON that isn't a dictionary."""
+    data_file.parent.mkdir(parents=True, exist_ok=True)
+    data_file.write_text(json.dumps([{"id": "a"}, {"id": "b"}])) 
+
+    with caplog.at_level(logging.ERROR):
+        client = FileIssueTrackerClient(filepath=str(data_file))
+        assert len(client.get_issue_dict()) == 0
+        assert f"Invalid data format in {data_file}" in caplog.text
+
+
+def test_directory_creation(tmp_path: Path):
+    """Test that the client creates the data directory if it doesn't exist."""
+    non_existent_dir = tmp_path / "new_data_dir"
+    data_file = non_existent_dir / "issues.json"
+
+    assert not non_existent_dir.exists()
+
+    client = FileIssueTrackerClient(filepath=str(data_file))
+    assert non_existent_dir.exists()
+    assert non_existent_dir.is_dir()
+
+
+def test_save_and_reload(data_file: Path):
+    """Test saving data and reloading it in a new client instance."""
+    # client 1 creates data,
+    client1 = FileIssueTrackerClient(filepath=str(data_file))
+    client1.set_current_user("first_user")
+    issue1 = client1.create_issue("Save Test", "Data to be saved")
+    client1.add_comment(issue1.id, "A comment to save")
+
+    # client 2 loads data added by client 1 
+    client2 = FileIssueTrackerClient(filepath=str(data_file))
+    assert len(client2.get_issue_dict()) == 1
+    loaded_issue = client2.get_issue(issue1.id)
+
+    assert loaded_issue.title == "Save Test"
+    assert loaded_issue.creator == "first_user"
+    comments = list(loaded_issue.get_comments())
+    assert len(comments) == 1
+    assert comments[0].content == "A comment to save"


### PR DESCRIPTION

## Description

This PR introduces persistent storage for the issue tracker backend. Instead of storing issues only in memory (lost when the application stops), issues and comments are now saved to and loaded from a JSON file (data/issues.json). MemoryIssueTrackerClient is replaced by FileIssueTrackerClient across the codebase. MemoryIssueTrackerClient remains available but is no longer the default.

Key changes include:
- Added to_dict() and from_dict() serialization methods to MemoryIssue and MemoryComment.
- Created FileIssueTrackerClient which handles loading issues from a specified JSON file on initialization and saving the entire issue state (as a dictionary keyed by issue ID) back to the file after any modification (create, update, comment, close).
- Implemented error handling for file not found, invalid JSON, and incorrect data format during loading, logging warnings/errors and starting with an empty state.
- Updated get_issue_tracker_client() in issue_tracker_interface.py to return FileIssueTrackerClient by default.
- Refactored test_issue_tracker.py to thoroughly test FileIssueTrackerClient, using tmp_path for test isolation and adding specific tests aimed at persistence.
- Updated tests/ai_issue_integration_test.py fixture to use FileIssueTrackerClient 
- Fixed command matching logic in AIIssueIntegration to correctly handle space-separated commands 

## Motivation and Context

The previous implementation of the issue tracker was purely in-memory, which severely limited the practical usability of the tracker. The implementation of a simple file-based persistence allows the retainence of data between application runs, and we chose this over a database as a first step.

## Screenshots
N/A

## Testing
1. Run `pytest` to ensure tests pass.
2. Verify logs are correctly recorded.

## Related Issues

Link any related issues this pull request addresses.

## Checklist
- [x ] Code follows style guide (`ruff check`, `ruff format`)
- [ ] Static typing enforced (`mypy .`)
- [x ] Tests pass (`pytest`)
- [x ] Test coverage is sufficient (`coverage.py`)
- [ ] Documentation updated if needed

## Related Issues
N/A
